### PR TITLE
Moment is not a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "dependencies": {
     "debug": "^2.2.0",
     "fs-extra": "^2.0.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "moment": "^2.17.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-moment-js": "^1.0.0",
     "dirty-chai": "^1.2.2",
-    "metalsmith": "^2.3.0",
-    "moment": "^2.17.1"
+    "metalsmith": "^2.3.0"
   }
 }


### PR DESCRIPTION
Hi there,

I couldn't run the plugin and realised that it was because it required moment as a devDependency!

Cheers,

Jun